### PR TITLE
Add Expiry Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Reads NZ COVID Pass passes, validates them, and lets you look at the data inside
   puts covid_pass.given_name
   puts covid_pass.family_name # note: can be nil
   puts covid_pass.dob
+  puts covid_pass.expiry
 ```
 
 If there's a problem with the pass, you'll get an exception raised:
@@ -32,7 +33,7 @@ If you want to try out the test COVID Passes, you'll need to enable the test opt
   covid_pass = NZCovidPass.new(test_code, allow_test_issuers: true)
 ```
 
-This gem requires network access to fetch the public key for validation.  If
+This gem requires network access to fetch the public key for validation. If
 you don't have network access, or you're going to be validating lots of passes,
 you can pass in a cache hash:
 

--- a/lib/nz_covid_pass.rb
+++ b/lib/nz_covid_pass.rb
@@ -65,6 +65,10 @@ class NZCovidPass
     credential_subject["dob"] && Date.parse(credential_subject["dob"])
   end
 
+  def expiry
+    Time.at(cwt.exp).utc.to_datetime
+  end
+
   def jti
     cti = cwt.cti
     if cti.length == 16

--- a/test/nz_covid_pass_test.rb
+++ b/test/nz_covid_pass_test.rb
@@ -10,6 +10,7 @@ class TestCovidPasses < Test::Unit::TestCase
     assert_equal("Jack", covid_pass.given_name)
     assert_equal("Sparrow", covid_pass.family_name)
     assert_equal("1960-04-16", covid_pass.dob.to_s)
+    assert_equal("2031-11-02T20:05:30+00:00", covid_pass.expiry.to_s)
     assert_equal("urn:uuid:60a4f54d-4e30-4332-be33-ad78b1eafa4b", covid_pass.jti)
   end
 


### PR DESCRIPTION
### Changes

- Add expiry date/time to public methods on `NzCovidPass` instances.
- Required for an implementation where we want to allow access based on a valid pass, but expire that access in the future (when the pass expires) without storing the full pass details.